### PR TITLE
Fix unsubscribe to not fail if there is no subscription

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,17 +75,19 @@ SubscriptionManager.prototype.unsubscribe = function(thing, channel) {
   channel = this.prefix + channel;
   var subscribers = this.subscriptions[channel];
 
-  for (var i=subscribers.length-1; i>=0; i--) {
-    var subscriber = subscribers[i];
-    if (subscriber === thing) {
-      subscribers.splice(i, 1);
-      break;
+  if (subscribers) {
+    for (var i=subscribers.length-1; i>=0; i--) {
+      var subscriber = subscribers[i];
+      if (subscriber === thing) {
+        subscribers.splice(i, 1);
+        break;
+      }
     }
-  }
 
-  if (subscribers.length === 0) {
-    delete this.subscriptions[channel];
-    this.redis.unsubscribe(channel);
+    if (subscribers.length === 0) {
+      delete this.subscriptions[channel];
+      this.redis.unsubscribe(channel);
+    }
   }
 };
 

--- a/test/index.js
+++ b/test/index.js
@@ -135,6 +135,14 @@ describe('SubscriptionManager', function() {
       checkChannelList(['test2'], done);
     });
 
+    it('should not crash when unsubscribing from an unused channel', function(done) {
+      s = new SubMan(r);
+      s.unsubscribe(obj1, 'test1');
+
+      var subs1 = s.subscriptions.test1;
+      (typeof subs1).should.eql('undefined');
+      return done();
+    });
   });
 
 


### PR DESCRIPTION
Before, if we called unsubscribe on a channel that was already empty, it would throw an error. This commit fixes that. Now, it will simply continue, because the action (unsubscribing) has already taken place.
